### PR TITLE
Setup profiling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ TAGS
 
 *.swp
 
+
+prof.aux
+prof.hp
+prof.ps
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONEY: prof
+prof:
+	cabal run
+	hp2ps -e8in -c prof.hp
+	evince prof.ps
+
+.PHONEY: clean
+clean:
+	rm -rf prof.aux prof.hp prof.ps

--- a/course.cabal
+++ b/course.cabal
@@ -81,6 +81,24 @@ library
                       Course.Traversable
                       Course.Validation
 
+executable prof
+  main-is:
+                      Prof.hs
+
+  hs-source-dirs:     src
+
+  default-language:
+                      Haskell2010
+
+  build-depends:
+                      base
+
+  --ghc-options:
+  --                    -O2
+
+  ghc-prof-options:
+                      "-with-rtsopts = -s -hy -i0.00001"
+
 test-suite            doctests
   type:
                       exitcode-stdio-1.0

--- a/src/Prof.hs
+++ b/src/Prof.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Prelude
+import Data.Foldable (foldl')
+
+main :: IO ()
+main = print $ foldl' (+) 0 [1..100000]
+-- main = print $ foldr (+) 0 [1..100000]


### PR DESCRIPTION
I've added an executable called prof and turned on some ghc profiling flags. If you run "cabal configure --enable-executable-profiling" and then "make" you should get some run-time statistics printed to standard out and a graph. The makefile uses evince to show the generated postscript graph. Switch between right fold and strict left fold in src/Prof.hs to see the difference in maximum resident memory. foldRight is like foldr and foldLeft is like foldl'.
